### PR TITLE
Add correct argument flag to borg probe

### DIFF
--- a/bin/src/commands/probe_command.dart
+++ b/bin/src/commands/probe_command.dart
@@ -34,11 +34,13 @@ import 'package:path/path.dart' as path;
 import 'package:pubspec_lock/pubspec_lock.dart';
 
 import '../assert_pubspec_yaml_consistency.dart';
+import '../options/correct.dart';
 import '../options/lock.dart';
 import '../options/verbose.dart';
 import '../options/yaml.dart';
 import '../scan_for_packages.dart';
 import '../utils/borg_exception.dart';
+import '../utils/correct_package_dependency.dart';
 import '../utils/print_dependency_usage_report.dart';
 
 // ignore_for_file: avoid_print
@@ -49,6 +51,7 @@ class ProbeCommand extends Command<void> {
     addPubspecYamlFlag(argParser);
     addPubspecLockFlag(argParser);
     addVerboseFlag(argParser);
+    addCorrectFlag(argParser);
   }
 
   @override
@@ -114,13 +117,16 @@ class ProbeCommand extends Command<void> {
     print('Analyzing dependencies...');
     final inconsistentUsageList = findInconsistentDependencies(pubspecLocks);
 
-    if (inconsistentUsageList.isNotEmpty) {
+    if (inconsistentUsageList.isNotEmpty && getCorrectFlag(argResults)) {
+      correctPackageDependencyBasedOnReport(report: inconsistentUsageList);
+    } else if (inconsistentUsageList.isNotEmpty) {
       printDependencyUsageReport(
         report: inconsistentUsageList,
         formatDependency: _formatDependencyInfo,
       );
       throw const BorgException(
-          'FAILURE: Inconsistent use of external dependencies detected!');
+        'FAILURE: Inconsistent use of external dependencies detected!',
+      );
     }
   }
 }

--- a/bin/src/options/correct.dart
+++ b/bin/src/options/correct.dart
@@ -23,38 +23,15 @@
  *
  */
 
-import 'package:borg/borg.dart';
-import 'package:meta/meta.dart';
+import 'package:args/args.dart';
 
-// ignore_for_file: avoid_print
-
-void printDependencyUsageReport<DependencyType>({
-  @required List<DependencyUsageReport<DependencyType>> report,
-  @required String Function(DependencyType dependency) formatDependency,
-}) {
-  final sortedUses = report
-    ..sort((a, b) => a.dependencyName.compareTo(b.dependencyName));
-
-  for (final use in sortedUses) {
-    print(
-      '\n${use.dependencyName}: '
-      'inconsistent dependency specifications detected',
+void addCorrectFlag(ArgParser argParser) => argParser.addFlag(
+      _name,
+      abbr: 'c',
+      help: 'Prompt user to correct found issues.',
     );
-    printDependencyUsage(
-      dependencies: use.references,
-      formatDependency: formatDependency,
-    );
-  }
-}
 
-void printDependencyUsage<DependencyType>({
-  @required Map<DependencyType, List<String>> dependencies,
-  @required String Function(DependencyType dependency) formatDependency,
-}) {
-  for (final dependency in dependencies.keys) {
-    print('\tVersion ${formatDependency(dependency)} is used by:');
-    for (final user in dependencies[dependency]) {
-      print('\t\t$user');
-    }
-  }
-}
+// ignore: avoid_as
+bool getCorrectFlag(ArgResults argResults) => argResults[_name] as bool;
+
+const _name = 'correct';

--- a/bin/src/utils/correct_package_dependency.dart
+++ b/bin/src/utils/correct_package_dependency.dart
@@ -1,0 +1,83 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Alexei Sintotski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+import 'dart:io';
+
+import 'package:borg/borg.dart';
+import 'package:borg/src/package_dependency_to_version.dart';
+import 'package:meta/meta.dart';
+import 'package:pubspec_lock/pubspec_lock.dart';
+
+import 'borg_exception.dart';
+import 'print_dependency_usage_report.dart';
+
+// ignore_for_file: avoid_print
+
+void correctPackageDependencyBasedOnReport({
+  @required List<DependencyUsageReport<PackageDependency>> report,
+}) {
+  final reports = report
+    ..sort((a, b) => a.dependencyName.compareTo(b.dependencyName));
+
+  for (final report in reports) {
+    final dependencyName = report.dependencyName;
+    print('\n$dependencyName: inconsistent dependency specifications detected');
+    printDependencyUsage<PackageDependency>(
+      dependencies: report.references,
+      formatDependency: (dependency) => dependency.version(),
+    );
+
+    final inconsistentVersions = report.references.keys.map(
+      (package) => package.version(),
+    );
+
+    print('\nChange "$dependencyName" version to? $inconsistentVersions');
+    final userInput = stdin.readLineSync();
+    if (inconsistentVersions.contains(userInput)) {
+      for (final reference in report.references.entries) {
+        final newPubspecLocks = packageDependencyToVersion(
+          dependency: reference.key,
+          inPubspecLocks: reference.value.asMap().map(
+                (_, path) => MapEntry(
+                  path,
+                  File(path).readAsStringSync().loadPubspecLockFromYaml(),
+                ),
+              ),
+          toVersion: userInput,
+        );
+        for (final newPubspecLock in newPubspecLocks.entries) {
+          File(newPubspecLock.key).writeAsStringSync(
+            newPubspecLock.value.toYamlString(),
+          );
+        }
+      }
+    } else {
+      throw BorgException(
+        'FAILURE: Version "$userInput" did not match '
+        'any $inconsistentVersions',
+      );
+    }
+  }
+}

--- a/lib/src/package_dependency_to_version.dart
+++ b/lib/src/package_dependency_to_version.dart
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Alexei Sintotski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+import 'package:meta/meta.dart';
+import 'package:pubspec_lock/pubspec_lock.dart';
+
+/// This function sets a [dependency] to a specific [toVersion] by adjusting
+/// every pubspecLock found in the [inPubspecLocks] list. Returns the altered
+/// list.
+///
+Map<String, PubspecLock> packageDependencyToVersion({
+  @required PackageDependency dependency,
+  @required String toVersion,
+  @required Map<String, PubspecLock> inPubspecLocks,
+}) {
+  if (dependency.version() == toVersion) {
+    return inPubspecLocks;
+  }
+
+  final newPackageDependency = dependency.iswitch<PackageDependency>(
+    sdk: (sdk) => PackageDependency.sdk(
+      sdk.copyWith(version: toVersion),
+    ),
+    hosted: (hosted) => PackageDependency.hosted(
+      hosted.copyWith(version: toVersion),
+    ),
+    git: (git) => PackageDependency.git(
+      git.copyWith(version: toVersion),
+    ),
+    path: (path) => PackageDependency.path(
+      path.copyWith(version: toVersion),
+    ),
+  );
+
+  return inPubspecLocks.map(
+    (path, pubspecLock) {
+      final packages = pubspecLock.packages.toList();
+      final replacementIndex = packages.indexWhere(
+        (p) => p.package() == dependency.package(),
+      );
+      packages[replacementIndex] = newPackageDependency;
+      return MapEntry(path, pubspecLock.copyWith(packages: packages));
+    },
+  );
+}

--- a/test/set_package_dependencies_to_version_test.dart
+++ b/test/set_package_dependencies_to_version_test.dart
@@ -1,0 +1,125 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Alexei Sintotski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+import 'package:borg/src/package_dependency_to_version.dart';
+import 'package:pubspec_lock/pubspec_lock.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('setPackageDependenciesToVersion', () {
+    group('when provided with no pubspec lock objects', () {
+      final newPubspecLocks = packageDependencyToVersion(
+        dependency: _hostedDependencyAv1,
+        inPubspecLocks: {},
+        toVersion: '1.0.0',
+      );
+
+      test('it returns an empty pubspec locks list', () {
+        expect(newPubspecLocks, isEmpty);
+      });
+    });
+
+    group('when provided a pubspec.lock not containing the dependency', () {
+      final pubspecLocks = {
+        'a': const PubspecLock(packages: [_hostedDependencyAv2])
+      };
+
+      final newPubspecLocks = packageDependencyToVersion(
+        dependency: _hostedDependencyAv1,
+        toVersion: '1.0.0',
+        inPubspecLocks: pubspecLocks,
+      );
+
+      test('it provides the same pubspec locks', () {
+        expect(newPubspecLocks, pubspecLocks);
+      });
+    });
+
+    group('when provided pubspec.lock objects containing the dependency', () {
+      const version = '1.1.0';
+
+      final pubspecLocks = {
+        'a': const PubspecLock(packages: [
+          _hostedDependencyAv1,
+          _hostedDependencyAv2,
+        ]),
+        'b': const PubspecLock(packages: [
+          _hostedDependencyAv1,
+          _hostedDependencyAv2,
+        ]),
+        'c': const PubspecLock(packages: [
+          _hostedDependencyAv1,
+          _hostedDependencyAv2,
+        ]),
+        'd': const PubspecLock(packages: [
+          _hostedDependencyAv1,
+          _hostedDependencyAv2,
+        ])
+      };
+
+      final newPubspecLocks = packageDependencyToVersion(
+        dependency: _hostedDependencyAv1,
+        toVersion: version,
+        inPubspecLocks: pubspecLocks,
+      );
+
+      test('it changes $_hostedDependencyAv1 packages to version $version', () {
+        for (final pubspecLock in newPubspecLocks.entries) {
+          for (final package in pubspecLock.value.packages) {
+            if (package.package() == _hostedDependencyAv1.package()) {
+              expect(package.version(), version);
+            }
+          }
+        }
+      });
+
+      test('it did not change $_hostedDependencyAv2 packages', () {
+        for (final pubspecLock in newPubspecLocks.entries) {
+          for (final package in pubspecLock.value.packages) {
+            if (package.package() == _hostedDependencyAv2.package()) {
+              expect(package.version(), _hostedDependencyAv2.version());
+            }
+          }
+        }
+      });
+    });
+  });
+}
+
+const _hostedDependencyAv1 = PackageDependency.hosted(HostedPackageDependency(
+  package: 'a',
+  version: '1.0.0',
+  name: 'a',
+  url: 'https://pub.dartlang.org',
+  type: DependencyType.direct,
+));
+
+const _hostedDependencyAv2 = PackageDependency.hosted(HostedPackageDependency(
+  package: 'b',
+  version: '2.0.0',
+  name: 'b',
+  url: 'https://pub.dartlang.org',
+  type: DependencyType.development,
+));


### PR DESCRIPTION
For every inconsistency found during borg probe, the user will be asked which version to select. The pubspec lock file is rewritten afterwards with the chosen version.