### PR TITLE
Add support for circular dependency detection

### DIFF
--- a/bin/src/assert_pubspec_yaml_consistency.dart
+++ b/bin/src/assert_pubspec_yaml_consistency.dart
@@ -46,7 +46,7 @@ void assertPubspecYamlConsistency(Iterable<DartPackage> packages) {
   );
 
   if (inconsistentSpecList.isNotEmpty) {
-    printDependencyUsageReport(
+    printInconsistentDependencyUsageReport(
       report: inconsistentSpecList,
       formatDependency: _formatDependencySpec,
     );

--- a/bin/src/utils/borg_exception.dart
+++ b/bin/src/utils/borg_exception.dart
@@ -31,9 +31,13 @@ import 'package:meta/meta.dart';
 
 @immutable
 class BorgException implements Exception {
-  const BorgException(this.message);
+  const BorgException(
+    this.message, {
+    this.supportMessage,
+  });
 
   final String message;
+  final String? supportMessage;
 }
 
 void exitWithMessageOnBorgException({
@@ -42,8 +46,12 @@ void exitWithMessageOnBorgException({
 }) {
   try {
     action();
-  } on BorgException catch (e) {
-    print(e.message);
+  } on BorgException catch (exception) {
+    print(exception.message);
+    if (exception.supportMessage != null) {
+      print(exception.supportMessage);
+    }
+
     exit(exitCode);
   }
 }

--- a/bin/src/utils/print_dependency_usage_report.dart
+++ b/bin/src/utils/print_dependency_usage_report.dart
@@ -27,7 +27,7 @@ import 'package:borg/borg.dart';
 
 // ignore_for_file: avoid_print
 
-void printDependencyUsageReport<DependencyType>({
+void printInconsistentDependencyUsageReport<DependencyType>({
   required List<DependencyUsageReport<DependencyType>> report,
   required String Function(DependencyType dependency) formatDependency,
 }) {
@@ -39,11 +39,33 @@ void printDependencyUsageReport<DependencyType>({
       '\n${use.dependencyName}: '
       'inconsistent dependency specifications detected',
     );
+
     printDependencyUsage(
       dependencies: use.references,
       formatDependency: formatDependency,
     );
   }
+
+  print('');
+}
+
+void printCircularDependencyUsageReport<DependencyType>({
+  required List<DependencyUsageReport<DependencyType>> report,
+  required String Function(DependencyType dependency) formatDependency,
+}) {
+  for (final use in report) {
+    print(
+      '\n${use.dependencyName}: '
+      'circular dependency detected',
+    );
+
+    printDependencyUsage(
+      dependencies: use.references,
+      formatDependency: formatDependency,
+    );
+  }
+
+  print('');
 }
 
 void printDependencyUsage<DependencyType>({

--- a/lib/src/dart_package/dart_package.dart
+++ b/lib/src/dart_package/dart_package.dart
@@ -23,6 +23,8 @@
  *
  */
 
+import 'dart:io';
+
 import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:plain_optional/plain_optional.dart';
@@ -47,11 +49,13 @@ class DartPackage {
         pubspecLock = tryToReadFileSync(join(path, 'pubspec.lock')).iif(
           some: (content) => Optional(content.loadPubspecLockFromYaml()),
           none: () => const Optional.none(),
-        );
+        ),
+        pubspecLockFile = File(join(path, 'pubspec.lock'));
 
   final String path;
   final PubspecYaml pubspecYaml;
   final Optional<PubspecLock> pubspecLock;
+  final File pubspecLockFile;
 
   bool get isFlutterPackage =>
       pubspecYaml.dependencies.any((d) => d.package() == 'flutter');

--- a/lib/src/find_circular_dependencies.dart
+++ b/lib/src/find_circular_dependencies.dart
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Alexei Sintotski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+import 'package:pubspec_lock/pubspec_lock.dart';
+
+import 'dart_package/dart_package.dart';
+import 'generic_dependency_usage_report.dart';
+
+/// Finds circular dependencies in the provided set of
+/// pubspec.lock content and generates report on inconsistent package usage.
+Iterable<DependencyUsageReport<PackageDependency>> findCircularDependencies(
+  Map<DartPackage, PubspecLock> pubspecLocks,
+) sync* {
+  for (final package in pubspecLocks.entries) {
+    final packagesDependingOnCurrentPackage = pubspecLocks.entries
+        .where((pubspecLock) => pubspecLock.key != package.key)
+        .where(
+          (pubspecLock) => pubspecLock.value.packages.any((dependency) =>
+              package.key.pubspecYaml.name == dependency.package()),
+        )
+        .map((pubspecLock) => pubspecLock.key.pubspecYaml.name)
+        .toList();
+
+    final circularDependencies = package.value.packages
+        .where((dependency) =>
+            packagesDependingOnCurrentPackage.contains(dependency.package()))
+        .toSet();
+
+    if (circularDependencies.isNotEmpty) {
+      yield DependencyUsageReport(
+        dependencyName: package.key.pubspecYaml.name,
+        references: {
+          for (final dependency in circularDependencies)
+            dependency: [package.key.pubspecYaml.name],
+        },
+      );
+    }
+  }
+}

--- a/test/dart_package_utils.dart
+++ b/test/dart_package_utils.dart
@@ -1,0 +1,13 @@
+import 'package:borg/src/dart_package/dart_package.dart';
+import 'package:plain_optional/plain_optional.dart';
+
+DartPackage dartPackage(String name) => DartPackage(
+      path: '/$name',
+      tryToReadFileSync: (path) {
+        if (path.endsWith('pubspec.yaml')) {
+          return Optional('name: $name');
+        }
+
+        return const Optional.none();
+      },
+    );

--- a/test/find_circular_dependencies_test.dart
+++ b/test/find_circular_dependencies_test.dart
@@ -1,0 +1,109 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Alexei Sintotski
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+import 'package:borg/src/find_circular_dependencies.dart';
+import 'package:borg/src/generic_dependency_usage_report.dart';
+import 'package:pubspec_lock/pubspec_lock.dart';
+import 'package:test/test.dart';
+
+import 'dart_package_utils.dart';
+
+void main() {
+  final packageA = dartPackage('a');
+  final packageB = dartPackage('b');
+  final packageC = dartPackage('c');
+
+  const dependencyToA = PackageDependency.path(
+    PathPackageDependency(
+      package: 'a',
+      version: '1',
+      path: '/',
+      relative: true,
+      type: DependencyType.direct,
+    ),
+  );
+
+  const dependencyToB = PackageDependency.path(
+    PathPackageDependency(
+      package: 'b',
+      version: '1',
+      path: '/',
+      relative: true,
+      type: DependencyType.direct,
+    ),
+  );
+
+  group('when the provided list contains a circular dependencies', () {
+    final report = findCircularDependencies({
+      packageA: const PubspecLock(
+        packages: [dependencyToB],
+      ),
+      packageB: const PubspecLock(
+        packages: [dependencyToA],
+      ),
+      packageC: const PubspecLock(
+        packages: [dependencyToA],
+      ),
+    }).toList();
+
+    test('then all circular dependencies are reported', () {
+      expect(
+        report,
+        equals([
+          DependencyUsageReport<PackageDependency>(
+            dependencyName: packageA.pubspecYaml.name,
+            references: {
+              dependencyToB: const ['a']
+            },
+          ),
+          DependencyUsageReport<PackageDependency>(
+            dependencyName: packageB.pubspecYaml.name,
+            references: {
+              dependencyToA: const ['b']
+            },
+          ),
+        ]),
+      );
+    });
+  });
+
+  group('when the provided list contains no circular dependencies', () {
+    final report = findCircularDependencies({
+      packageA: const PubspecLock(
+        packages: [],
+      ),
+      packageB: const PubspecLock(
+        packages: [dependencyToA],
+      ),
+      packageC: const PubspecLock(
+        packages: [dependencyToA],
+      ),
+    }).toList();
+
+    test('then no circular dependencies are reported', () {
+      expect(report, const <DependencyUsageReport<PackageDependency>>[]);
+    });
+  });
+}

--- a/test/find_inconsistent_dependencies_test.dart
+++ b/test/find_inconsistent_dependencies_test.dart
@@ -28,6 +28,8 @@ import 'package:borg/src/generic_dependency_usage_report.dart';
 import 'package:pubspec_lock/pubspec_lock.dart';
 import 'package:test/test.dart';
 
+import 'dart_package_utils.dart';
+
 void main() {
   group('findInconsistentDependencies', () {
     group('when provided with empty input', () {
@@ -39,7 +41,7 @@ void main() {
 
     group('when provided with single pubspec.lock', () {
       final report = findInconsistentDependencies({
-        'a': const PubspecLock(packages: [_hostedDependencyAv1])
+        dartPackage('a'): const PubspecLock(packages: [_hostedDependencyAv1])
       });
       test('it provides empty report', () {
         expect(report, isEmpty);
@@ -48,8 +50,8 @@ void main() {
 
     group('when provided with two conherent instances of pubspec.lock', () {
       final report = findInconsistentDependencies({
-        'a1': const PubspecLock(packages: [_hostedDependencyAv1]),
-        'a2': const PubspecLock(packages: [_hostedDependencyAv1]),
+        dartPackage('a1'): const PubspecLock(packages: [_hostedDependencyAv1]),
+        dartPackage('a2'): const PubspecLock(packages: [_hostedDependencyAv1]),
       });
       test('it provides empty report', () {
         expect(report, isEmpty);
@@ -59,8 +61,8 @@ void main() {
     group('when provided with two distinct versions of a hosted dependency',
         () {
       final report = findInconsistentDependencies({
-        'a1': const PubspecLock(packages: [_hostedDependencyAv1]),
-        'a2': const PubspecLock(packages: [_hostedDependencyAv2]),
+        dartPackage('a1'): const PubspecLock(packages: [_hostedDependencyAv1]),
+        dartPackage('a2'): const PubspecLock(packages: [_hostedDependencyAv2]),
       });
       test('provides correct report', () {
         expect(report, _reportAv1Av2);
@@ -70,8 +72,8 @@ void main() {
 
   group('when provided with two distinct versions of a path dependency', () {
     final report = findInconsistentDependencies({
-      'a1': const PubspecLock(packages: [_pathDependencyAv1]),
-      'a2': const PubspecLock(packages: [_pathDependencyAv2]),
+      dartPackage('a1'): const PubspecLock(packages: [_pathDependencyAv1]),
+      dartPackage('a2'): const PubspecLock(packages: [_pathDependencyAv2]),
     });
     test('it provides empty report', () {
       expect(report, isEmpty);
@@ -80,8 +82,8 @@ void main() {
 
   group('when provided with two hosted and path versions of a dependency', () {
     final report = findInconsistentDependencies({
-      'a1': const PubspecLock(packages: [_hostedDependencyAv1]),
-      'a2': const PubspecLock(packages: [_pathDependencyAv1]),
+      dartPackage('a1'): const PubspecLock(packages: [_hostedDependencyAv1]),
+      dartPackage('a2'): const PubspecLock(packages: [_pathDependencyAv1]),
     });
     test('it provides report with a single entry', () {
       expect(report.length, 1);
@@ -93,8 +95,9 @@ void main() {
     'dependency type only',
     () {
       final report = findInconsistentDependencies({
-        'a1': const PubspecLock(packages: [_hostedDependencyAv1]),
-        'a2': const PubspecLock(packages: [_hostedDependencyAv1Transitive]),
+        dartPackage('a1'): const PubspecLock(packages: [_hostedDependencyAv1]),
+        dartPackage('a2'):
+            const PubspecLock(packages: [_hostedDependencyAv1Transitive]),
       });
       test('it provides empty report', () {
         expect(report, isEmpty);
@@ -139,9 +142,9 @@ final _reportAv1Av2 = [
     dependencyName: 'a',
     references: {
       // ignore: prefer_const_literals_to_create_immutables
-      _hostedDependencyAv1: ['a1'],
+      _hostedDependencyAv1: ['/a1/pubspec.lock'],
       // ignore: prefer_const_literals_to_create_immutables
-      _hostedDependencyAv2: ['a2'],
+      _hostedDependencyAv2: ['/a2/pubspec.lock'],
     },
   )
 ];


### PR DESCRIPTION
Semi-Draft PR to add circular dependency detection, would love to get your initial feedback.

- [ ] Update docs

Example output:

```
Scanning for Dart packages... XXX packages found

Analyzing dependency specifications...

Analyzing dependencies...

a: circular dependency detected
	Version ../b is used by:
		a

b: circular dependency detected
	Version ../a is used by:
		b

FAILURE: Inconsistent use of (external) dependencies detected!
```