### PR TITLE
Added profiler flag to boot that prints the duration of bootstrapping

### DIFF
--- a/.run/Boot.run.xml
+++ b/.run/Boot.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Boot" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="arguments" value="boot" />
+    <option name="filePath" value="$PROJECT_DIR$/bin/main.dart" />
+    <option name="workingDirectory" value="$PROJECT_DIR$" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/bin/src/commands/boot_command.dart
+++ b/bin/src/commands/boot_command.dart
@@ -30,6 +30,7 @@ import 'package:borg/src/context/borg_context.dart';
 import 'package:borg/src/context/borg_context_factory.dart';
 
 import '../options/boot_mode.dart';
+import '../options/profiler.dart';
 import '../options/verbose.dart';
 import '../utils/borg_exception.dart';
 import 'boot_command_runner.dart';
@@ -47,6 +48,7 @@ class BootCommand extends Command<void> {
       ),
     );
     addVerboseFlag(argParser);
+    addProfilerFlag(argParser);
   }
 
   @override
@@ -72,6 +74,7 @@ class BootCommand extends Command<void> {
 
   static final BorgConfigurationFactory configurationFactory =
       BorgConfigurationFactory();
+
   // ignore: prefer_const_constructors
   static final BorgContextFactory contextFactory = BorgContextFactory();
   final BorgContext context;

--- a/bin/src/options/profiler.dart
+++ b/bin/src/options/profiler.dart
@@ -1,0 +1,37 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Jean Herfs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+import 'package:args/args.dart';
+
+void addProfilerFlag(ArgParser argParser) => argParser.addFlag(
+  _name,
+  abbr: 'r',
+  help: 'Adds information about the performance of package bootstrapping',
+);
+
+// ignore: avoid_as
+bool getProfilerFlag(ArgResults argResults) => argResults[_name] as bool;
+
+const _name = 'profiler';

--- a/bin/src/utils/print_colors.dart
+++ b/bin/src/utils/print_colors.dart
@@ -1,0 +1,13 @@
+import 'dart:core';
+
+void printGreen(String text) {
+  print('\x1B[32m$text\x1B[0m');
+}
+
+void printOrange(String text) {
+  print('\x1B[33m$text\x1B[0m');
+}
+
+void printRed(String text) {
+  print('\x1B[31m$text\x1B[0m');
+}


### PR DESCRIPTION
Added a flag to `dart boot` that will print the duration of bootstrapping per package and the total duration. At the end it will print a list of packages from slow to fast. Packages that take a long time to bootstrap are marked in red and orange colors.